### PR TITLE
Export ICookie interface

### DIFF
--- a/packages/cookie-universal/types/index.d.ts
+++ b/packages/cookie-universal/types/index.d.ts
@@ -13,7 +13,7 @@ interface ICookieSetOpts {
   opts?: CookieSerializeOptions
 }
 
-interface ICookie {
+export interface ICookie {
   get: (name: string, opts?: ICookieGetOpts) => any
   getAll: (opts?: ICookieGetOpts) => object
   set: (
@@ -26,6 +26,4 @@ interface ICookie {
   removeAll: () => void
 }
 
-declare const Cookie: (req?: object, res?: object, opts?: boolean) => ICookie
-
-export = Cookie
+export default function (req?: object, res?: object, opts?: boolean): ICookie


### PR DESCRIPTION
Assigning result of default export in user case, can lead to error like:

```
Declaration emit for this file requires using private name 'ICookie' from module '"/Users/.../node_modules/cookie-universal/types/index"'. An explicit type annotation may unblock declaration emit.
```

Fix by exporting ICookie interface also.

Resolves #52