### PR TITLE
fix(typing): remove misleading context typings

### DIFF
--- a/packages/cookie-universal-nuxt/types/index.d.ts
+++ b/packages/cookie-universal-nuxt/types/index.d.ts
@@ -30,18 +30,12 @@ export interface NuxtCookies {
 }
 
 declare module "@nuxt/vue-app" {
-  interface Context {
-    $cookies: NuxtCookies;
-  }
   interface NuxtAppOptions {
     $cookies: NuxtCookies;
   }
 }
 // Nuxt 2.9+
 declare module "@nuxt/types" {
-  interface Context {
-    $cookies: NuxtCookies;
-  }
   interface NuxtAppOptions {
     $cookies: NuxtCookies;
   }


### PR DESCRIPTION
Thank you for the library.
As I can see the plugin uses Nuxt’s inject funtion that injects variable into ctx.app, but not ctx, so I’m not sure what are Context typings for. This PR removes them.

Example:
```typescript
import { Plugin } from '@nuxt/types'

const plugin: Plugin = ({ $cookies }, inject) => {
  console.log($cookies) // logs undefiend, but current TS types allow it
}
```