### PR TITLE
Update index.d.ts to be able to type the return of the getters functions

### DIFF
--- a/packages/cookie-universal-nuxt/types/index.d.ts
+++ b/packages/cookie-universal-nuxt/types/index.d.ts
@@ -23,8 +23,8 @@ export interface NuxtCookies {
     opts?: CookieSerializeOptions
   ) => void;
   setAll: (cookieArray: SetParams[]) => void;
-  get: (name: string, opts?: GetOptions) => CookieValue;
-  getAll: (opts?: GetOptions) => CookieValue[];
+  get: <T = CookieValue>(name: string, opts?: GetOptions) => T;
+  getAll: <T = CookieValue[]>(opts?: GetOptions) => T;
   remove: (name: string, opts?: CookieSerializeOptions) => void;
   removeAll: () => void;
 }


### PR DESCRIPTION
Hey, I did not see any contributor guideline or anything. Hopefully, I'm doing things right.

I'd like to propose a small QOL change. To be able to type the return of a `$cookie.get` & `$cookie.getAll` which would default to any if not set.

Therefore this would be possible:

```ts
this.$cookie.set('hello', 'world');

const value = this.$cookie.get<string>('hello');
// value will be typed as a string instead of any;
```