### PR TITLE
Fix documentation for sameSite option

### DIFF
--- a/packages/cookie-universal-nuxt/README.md
+++ b/packages/cookie-universal-nuxt/README.md
@@ -89,7 +89,8 @@ this.$cookies.get('cookie-name', { parseJSON: false })
   - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
   - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
   - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-  - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+  - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+    Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
   - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js
@@ -133,7 +134,8 @@ this.$cookies.set('cookie-name', cookieValObject, {
     - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
     - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
     - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-    - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+    - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+      Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
     - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js
@@ -223,7 +225,8 @@ const cookiesRes = this.$cookies.getAll()
   - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
   - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
   - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-  - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+  - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+    Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
   - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js

--- a/packages/cookie-universal/README.md
+++ b/packages/cookie-universal/README.md
@@ -106,7 +106,8 @@ cookies.get('cookie-name', { parseJSON: false })
   - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
   - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
   - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-  - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+  - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+    Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
   - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js
@@ -153,7 +154,8 @@ cookies.set('cookie-name', cookieValObject, {
     - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
     - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
     - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-    - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+    - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+      Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
     - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js
@@ -252,7 +254,8 @@ const cookiesRes = cookies.getAll()
   - `httpOnly` (boolean): Specifies the boolean value for the [HttpOnly Set-Cookie attribute][rfc-6265-5.2.6].
   - `domain` (string): specifies the value for the Domain Set-Cookie attribute.
   - `encode` (function): Specifies a function that will be used to encode a cookie's value.
-  - `sameSite` (boolean|string): Specifies the value for the Path Set-Cookie attribute. By default, the path is considered the "default path".
+  - `sameSite` (boolean|string): Specifies the value for the [`SameSite` `Set-Cookie` attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7).  
+    Possible values: `true`, `false`, `'lax'`, `'none'`, `'strict'` ([see details](https://github.com/jshttp/cookie#samesite)). Default is `false`.
   - `secure` (boolean): Specifies the boolean value for the Secure Set-Cookie attribute.
 
 ```js


### PR DESCRIPTION
Hi,

Thanks for this very useful project.

I noticed that the documentation for the `sameSite` option was wrong, so I fixed it.

BTW, I think you can remove most of the options in the documentation of `remove()`.

Best regards,
Benoit